### PR TITLE
Fixed font-weight

### DIFF
--- a/supertokens.json
+++ b/supertokens.json
@@ -937,40 +937,49 @@
       "type": "lineHeights"
     },
     "font-thin": {
-      "value": "100",
-      "type": "fontWeights"
+      "value": "Thin",
+      "type": "fontWeights",
+      "description": "100"
     },
     "font-extralight": {
-      "value": "200",
-      "type": "fontWeights"
+      "value": "ExtraLight",
+      "type": "fontWeights",
+      "description": "200"
     },
     "font-light": {
-      "value": "300",
-      "type": "fontWeights"
+      "value": "Light",
+      "type": "fontWeights",
+      "description": "300"
     },
     "font-normal": {
-      "value": "400",
-      "type": "fontWeights"
+      "value": "Regular",
+      "type": "fontWeights",
+      "description": "400"
     },
     "font-medium": {
-      "value": "500",
-      "type": "fontWeights"
+      "value": "Medium",
+      "type": "fontWeights",
+      "description": "500"
     },
     "font-semibold": {
-      "value": "600",
-      "type": "fontWeights"
+      "value": "SemiBold",
+      "type": "fontWeights",
+      "description": "600"
     },
     "font-bold": {
-      "value": "700",
-      "type": "fontWeights"
+      "value": "Bold",
+      "type": "fontWeights",
+      "description": "700"
     },
     "font-extrabold": {
-      "value": "800",
-      "type": "fontWeights"
+      "value": "ExtraBold",
+      "type": "fontWeights",
+      "description": "800 (Not supported in IBM Plex Sans)"
     },
     "font-black": {
-      "value": "900",
-      "type": "fontWeights"
+      "value": "Black",
+      "type": "fontWeights",
+      "description": "900 (Not supported in IBM Plex Sans)"
     },
     "rounded-none": {
       "value": "0",


### PR DESCRIPTION
Previously the tokens were set to the numerical font weight. Discovered that the value needs to exactly match the values in the Figma weight selection. Ex: Instead of `800` you must use `ExtraBold`